### PR TITLE
Fix environment variable loading for Settings

### DIFF
--- a/pwb_alphaevolve/config.py
+++ b/pwb_alphaevolve/config.py
@@ -9,12 +9,14 @@ MAX_COMPLETION_TOKENS        – Token cap for LLM replies [4096]
 SQLITE_DB         – Path to SQLite file ["~/.pwb_alphaevolve/programs.db"]
 """
 
-from pathlib import Path
-from pydantic_settings import BaseSettings
-from pydantic import Field, field_validator
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
+    """Runtime configuration pulled from environment variables."""
+
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore", case_sensitive=False)
     # OpenAI
     openai_api_key: str = Field(..., env="OPENAI_API_KEY")
     openai_model: str = Field("o3-mini", env="OPENAI_MODEL")
@@ -32,12 +34,7 @@ class Settings(BaseSettings):
     @property
     def default_symbols(self) -> tuple[str, ...]:
         """Always returns a tuple of upper-case tickers."""
-        return tuple(
-            s.strip().upper() for s in self.default_symbols_raw.split(",") if s.strip()
-        )
-
-    class Config:
-        env_file = ".env"
+        return tuple(s.strip().upper() for s in self.default_symbols_raw.split(",") if s.strip())
 
 
 settings = Settings()


### PR DESCRIPTION
## Summary
- relax pydantic settings to ignore unknown env vars
- update Settings config to new pydantic v2 style

## Testing
- `ruff check pwb_alphaevolve/config.py --fix`
- `ruff check pwb_alphaevolve/config.py`
- `pytest -q` *(fails: command not found)*