### PR TITLE
Add market regime utility with fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 | LLM Engine | OpenAI o3 structured‑output chat → JSON diff/patch system                                   |
 | Evolution  | Async controller, SQLite hall‑of‑fame, optional MAP‑Elites niches                           |
 | Dashboard  | (optional) Streamlit live view of metrics & equity curves                                   |
+| Utilities  | Market regime filters for correlation-based signals |
 
 ---
 

--- a/pwb_alphaevolve/__init__.py
+++ b/pwb_alphaevolve/__init__.py
@@ -3,4 +3,5 @@
 __all__ = [
     "data",
     "strategies",
+    "utils",
 ]

--- a/pwb_alphaevolve/evolution/controller.py
+++ b/pwb_alphaevolve/evolution/controller.py
@@ -8,16 +8,18 @@ High‑level loop:
 5. Insert child into store (which updates MAP‑Elites grid).
 """
 
-import asyncio, json, inspect, textwrap, logging
+import asyncio
+import inspect
+import json
+import logging
 import textwrap
-from typing import Optional
 
-from pwb_alphaevolve.strategies.base import BaseLoggingStrategy
-from pwb_alphaevolve.store.sqlite import ProgramStore
-from pwb_alphaevolve.llm_engine import prompts, openai_client
-from pwb_alphaevolve.evolution.patching import apply_patch
 from pwb_alphaevolve.evaluator.backtest import evaluate
+from pwb_alphaevolve.evolution.patching import apply_patch
+from pwb_alphaevolve.llm_engine import openai_client, prompts
+from pwb_alphaevolve.store.sqlite import ProgramStore
 from pwb_alphaevolve.strategies import templates  # seed strategies
+from pwb_alphaevolve.strategies.base import BaseLoggingStrategy
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +43,7 @@ class Controller:
             self.store.insert(code, metrics=None, parent_id=None)
         logger.info("Seed strategies inserted into store.")
 
-    async def _spawn(self, parent_id: Optional[str]):
+    async def _spawn(self, parent_id: str | None):
         """Generate, evaluate & store one child strategy."""
         async with self.sem:
             # 1) Select parent
@@ -62,18 +64,14 @@ class Controller:
             try:
                 diff_json = json.loads(msg.content)
             except json.JSONDecodeError as e:
-                logger.error(
-                    f"Model did not return valid JSON: {e}\n{msg.content[:500]}"
-                )
+                logger.error(f"Model did not return valid JSON: {e}\n{msg.content[:500]}")
                 return
 
             child_startegy = apply_patch(parent["code"], diff_json)
 
             imports = "from collections import deque\nimport backtrader as bt"
             base_cls = inspect.getsource(BaseLoggingStrategy)
-            child_code = textwrap.dedent(
-                imports + "\n\n" + base_cls + "\n\n" + child_startegy
-            )
+            child_code = textwrap.dedent(imports + "\n\n" + base_cls + "\n\n" + child_startegy)
 
             # 4) Evaluate
             try:

--- a/pwb_alphaevolve/llm_engine/openai_client.py
+++ b/pwb_alphaevolve/llm_engine/openai_client.py
@@ -5,30 +5,28 @@
 * Centralised settings via `pwb_alphaevolve.config.settings`
 """
 
-import openai, asyncio
+from typing import Any
+
 import backoff
-from typing import List, Dict, Any
+import openai
 
 from pwb_alphaevolve.config import settings
 
 # Configure global client key
-openai.api_type = "openai"
-openai.api_key = settings.openai_api_key
+_client = openai.AsyncOpenAI(api_key=settings.openai_api_key)
 
 
-@backoff.on_exception(
-    backoff.expo, openai.OpenAIError, max_tries=5, jitter=backoff.full_jitter
-)
-async def chat(messages: List[Dict[str, str]], **kw) -> Any:
-    """Call OpenAI chat completion returning the `message` object of first choice."""
+@backoff.on_exception(backoff.expo, openai.OpenAIError, max_tries=5, jitter=backoff.full_jitter)
+async def chat(messages: list[dict[str, str]], **kw) -> Any:
+    """Call OpenAI chat completion returning the ``message`` object of the first choice."""
     # ensure response_format enforced
     response_format = {"type": "json_object"}
-    params = dict(
-        model=settings.openai_model,
-        messages=messages,
-        max_completion_tokens=settings.max_completion_tokens,
-        response_format=response_format,
-    )
+    params = {
+        "model": settings.openai_model,
+        "messages": messages,
+        "max_completion_tokens": settings.max_completion_tokens,
+        "response_format": response_format,
+    }
     params.update(kw)
-    completion = openai.chat.completions.create(**params)
+    completion = await _client.chat.completions.create(**params)
     return completion.choices[0].message

--- a/pwb_alphaevolve/strategies/templates.py
+++ b/pwb_alphaevolve/strategies/templates.py
@@ -5,6 +5,7 @@ controller.
 """
 
 import backtrader as bt
+
 from .base import BaseLoggingStrategy
 
 
@@ -12,13 +13,12 @@ from .base import BaseLoggingStrategy
 # ☀️  Template 1 – 10-month SMA cross on multiple assets
 # ---------------------------------------------------------------------
 class SMAMomentum(BaseLoggingStrategy):
-    params = dict(leverage=0.9, sma_period=210)
+    params = {"leverage": 0.9, "sma_period": 210}
 
     def __init__(self):
         super().__init__()
         self.sma = {
-            d._name: bt.indicators.SMA(d.close, period=self.p.sma_period)
-            for d in self.datas
+            d._name: bt.indicators.SMA(d.close, period=self.p.sma_period) for d in self.datas
         }
         self.last_month = -1
 
@@ -31,9 +31,7 @@ class SMAMomentum(BaseLoggingStrategy):
             return  # rebalance monthly
         self.last_month = today.month
 
-        tradable = [
-            d for d in self.datas if len(self.sma[d._name]) >= self.p.sma_period
-        ]
+        tradable = [d for d in self.datas if len(self.sma[d._name]) >= self.p.sma_period]
         longs = [d for d in tradable if d.close[0] > self.sma[d._name][0]]
 
         weight = self.p.leverage / len(longs) if longs else 0.0
@@ -47,13 +45,12 @@ class SMAMomentum(BaseLoggingStrategy):
 # ☀️  Template 2 – Volatility-adjusted momentum (placeholder)
 # ---------------------------------------------------------------------
 class VolAdjMomentum(BaseLoggingStrategy):
-    params = dict(leverage=0.95, lookback=63)
+    params = {"leverage": 0.95, "lookback": 63}
 
     def __init__(self):
         super().__init__()
         self.roc = {
-            d._name: bt.indicators.RateOfChange(d.close, period=self.p.lookback)
-            for d in self.datas
+            d._name: bt.indicators.RateOfChange(d.close, period=self.p.lookback) for d in self.datas
         }
         self.std = {
             d._name: bt.indicators.StandardDeviation(d.close, period=self.p.lookback)

--- a/pwb_alphaevolve/utils/metrics.py
+++ b/pwb_alphaevolve/utils/metrics.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 
 def _to_np(arr):
-    if isinstance(arr, (pd.Series, pd.DataFrame)):
+    if isinstance(arr, pd.Series | pd.DataFrame):
         arr = arr.values
     return np.asarray(arr, dtype=float)
 

--- a/pwb_alphaevolve/utils/regime.py
+++ b/pwb_alphaevolve/utils/regime.py
@@ -1,0 +1,46 @@
+"""Market regime detection utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def regime_signal(
+    df: pd.DataFrame,
+    *,
+    ticker: str,
+    benchmark: str = "SPY",
+    lookback: int = 63,
+    corr_threshold: float = 0.0,
+) -> pd.Series:
+    """Return +1 (buy) or -1 (sell) regime signal for ``ticker``.
+
+    Parameters
+    ----------
+    df : DataFrame
+        OHLC dataframe produced by :func:`load_ohlc` with multi-index columns
+        of the form ``(field, symbol)``.
+    ticker : str
+        Symbol for which to compute the regime signal.
+    benchmark : str, default 'SPY'
+        Benchmark symbol used for correlation.
+    lookback : int, default 63
+        Window length in trading days used for rolling correlation.
+    corr_threshold : float, default 0.0
+        Minimum correlation with the benchmark required to be considered
+        risk-on.  Values below this produce a -1 signal.
+    """
+    close = df["close"]
+    if ticker not in close or benchmark not in close:
+        raise KeyError("Symbols not found in DataFrame")
+
+    ret_ticker = close[ticker].pct_change()
+    ret_bench = close[benchmark].pct_change()
+
+    rolling_corr = ret_ticker.rolling(lookback).corr(ret_bench)
+    bench_trend = ret_bench.rolling(lookback).mean()
+
+    regime = (rolling_corr > corr_threshold) & (bench_trend > 0)
+    signal = np.where(regime, 1, -1)
+    return pd.Series(signal, index=df.index, name="signal")

--- a/tests/test_regime.py
+++ b/tests/test_regime.py
@@ -1,0 +1,25 @@
+import pandas as pd
+
+from pwb_alphaevolve.utils.regime import regime_signal
+
+
+def test_regime_signal_basic():
+    idx = pd.date_range("2020-01-01", periods=10)
+    data = {
+        ("close", "AAA"): [1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9],
+        ("close", "SPY"): [1, 1.05, 1.1, 1.15, 1.2, 1.25, 1.3, 1.35, 1.4, 1.45],
+    }
+    df = pd.DataFrame(data, index=idx)
+    sig = regime_signal(df, ticker="AAA", benchmark="SPY", lookback=3)
+    assert sig.iloc[-1] == 1
+
+
+def test_regime_signal_negative():
+    idx = pd.date_range("2020-01-01", periods=10)
+    data = {
+        ("close", "AAA"): [1, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1],
+        ("close", "SPY"): [1, 1.05, 1.1, 1.15, 1.2, 1.25, 1.3, 1.35, 1.4, 1.45],
+    }
+    df = pd.DataFrame(data, index=idx)
+    sig = regime_signal(df, ticker="AAA", benchmark="SPY", lookback=3)
+    assert sig.iloc[-1] == -1


### PR DESCRIPTION
## Summary
- expose `utils` in package exports
- add rolling correlation market regime filter
- fix async OpenAI client and tidy imports
- document new utilities
- add regression tests

## Testing
- `ruff check pwb_alphaevolve tests`
- `black pwb_alphaevolve tests -q`
- `pytest -q` *(fails: command not found)*